### PR TITLE
Move tagline to article footer

### DIFF
--- a/static/css/sidecar.css
+++ b/static/css/sidecar.css
@@ -74,13 +74,12 @@ body {
 .article__hgroup a:hover {
   text-decoration: underline;
 }
+.article__heading,
 .page__heading {
-  margin-top: 0;
   padding-top: 0;
 }
-.article__heading {
-  margin: 0;
-  padding: 0;
+.article--summary .article__heading {
+  padding-bottom: 0;
 }
 .article__tagline {
   margin-top: calc(0.25 * var(--oatcake-line-height));

--- a/templates/article.html
+++ b/templates/article.html
@@ -14,9 +14,9 @@
 {% set anchors = true %}
 
 {% block content %}
-  <hgroup class="article__hgroup">
-    <h1 class="article__heading noanchor">{{ article.title }}</h1>
-    {% include "includes/article/tagline.html" %}
-  </hgroup>
+  <h1 class="article__heading noanchor">{{ article.title }}</h1>
+
   <div class="article__content">{{ article.content }}</div>
+
+  <footer>{% include "includes/article/tagline.html" %}</footer>
 {% endblock %}

--- a/templates/includes/article/tagline.html
+++ b/templates/includes/article/tagline.html
@@ -35,4 +35,4 @@
   {% endif %}
 {% endfor %}
 
-<p class="article__tagline small secondary">{{ tagline_items|join(" &middot;&nbsp;") }}</p>
+<div class="article__tagline small secondary">{{ tagline_items|join(" &middot;&nbsp;") }}</div>


### PR DESCRIPTION
Move the article tagline to a `<footer>` at the bottom of the page on
article pages.

I prefer it here, don't like how it looks beneath the heading.
